### PR TITLE
Nameplate text formatting fixes, support for legacy color codes

### DIFF
--- a/src/main/java/me/youhavetrouble/notjustnameplates/text/TextParser.java
+++ b/src/main/java/me/youhavetrouble/notjustnameplates/text/TextParser.java
@@ -29,22 +29,22 @@ public class TextParser {
             final String placeholder = argumentQueue.popOr("placeholder tag requires an argument").value();
             switch (placeholder) {
                 case "name" -> {
-                    return Tag.selfClosingInserting(player.name());
+                    return Tag.inserting(player.name());
                 }
                 case "displayname" -> {
-                    return Tag.selfClosingInserting(player.displayName());
+                    return Tag.inserting(player.displayName());
                 }
                 default -> {
-                    if (!NotJustNameplates.isPapiHooked()) return Tag.selfClosingInserting(Component.text(placeholder));
+                    if (!NotJustNameplates.isPapiHooked()) return Tag.inserting(Component.text(placeholder));
 
                     final String parsedPlaceholder = PlaceholderAPI.setPlaceholders(player, '%' + placeholder + '%');
 
                     if (parsedPlaceholder.contains(LegacyComponentSerializer.SECTION_CHAR + "")) {
                         Component componentPlaceholder = LegacyComponentSerializer.legacySection().deserialize(parsedPlaceholder);
-                        return Tag.selfClosingInserting(componentPlaceholder);
+                        return Tag.inserting(componentPlaceholder);
                     }
 
-                    return Tag.selfClosingInserting(MiniMessage.miniMessage().deserialize(parsedPlaceholder));
+                    return Tag.inserting(MiniMessage.miniMessage().deserialize(parsedPlaceholder));
                 }
             }
 


### PR DESCRIPTION
### Changes summary
- Implemented a **custom tag parser for placeholders** instead of relying on a MiniMessage builder
  - Allows formatting from one placeholder to affect the text that follows
  - Fixes the issue where **tags that sat at the end of a placeholder would not be accounted for** (for example, a placeholder `"<red>OWNER <blue>"` would not make the text that follows the placeholder blue)
- Added **legacy color code support**

### Issues
---
Currently, it is not possible for a placeholder to affect the formatting of text that follows it. This is problematic if you need to color a player's name based upon a rank they have, for instance.

The image below uses the configuration `text: "<placeholder:luckperms_prefix> <placeholder:displayname>"` for the nametag. In LuckPerms, the prefix was set to `"<#00ccff>Example"`, but the name tag does not properly display the blue color across the entire plate as would be expected.

<img width="654" height="685" alt="Screenshot 2025-11-01 185721" src="https://github.com/user-attachments/assets/36e0858a-75d4-4603-ac13-03401f769452" />

---
This pull request solves this issue. Here is an image of the same configuration but with updated code:

<img width="645" height="704" alt="Screenshot 2025-11-01 185743" src="https://github.com/user-attachments/assets/625fbcc7-89c6-41c0-9c50-cd17d266c073" />

I also added support for legacy formatting codes like &1, &b, &l, etc.